### PR TITLE
Fix header include install failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ set(QtWebDAV_SOURCES
 set(QtWebDAV_HEADERS
     qnaturalsort.h
     qwebdav.h
-    qwebdav_global.h
     qwebdavdirparser.h
     qwebdavitem.h
 )


### PR DESCRIPTION
@m-kuhn , without this, vcpkg install fails (rightfully) complaining about a missing header file :)